### PR TITLE
Adaptação para linux

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,23 +77,23 @@
   </div>
 
   <section class="audios">
-    <audio data-key="65" src="/sounds/040.wav"></audio>
-    <audio data-key="87" src="/sounds/041.wav"></audio>
-    <audio data-key="83" src="/sounds/042.wav"></audio>
-    <audio data-key="69" src="/sounds/043.wav"></audio>
-    <audio data-key="68" src="/sounds/044.wav"></audio>
-    <audio data-key="70" src="/sounds/045.wav"></audio>
-    <audio data-key="84" src="/sounds/046.wav"></audio>
-    <audio data-key="71" src="/sounds/047.wav"></audio>
-    <audio data-key="89" src="/sounds/048.wav"></audio>
-    <audio data-key="72" src="/sounds/049.wav"></audio>
-    <audio data-key="85" src="/sounds/050.wav"></audio>
-    <audio data-key="74" src="/sounds/051.wav"></audio>
-    <audio data-key="75" src="/sounds/052.wav"></audio>
-    <audio data-key="79" src="/sounds/053.wav"></audio>
-    <audio data-key="76" src="/sounds/054.wav"></audio>
-    <audio data-key="80" src="/sounds/055.wav"></audio>
-    <audio data-key="186" src="/sounds/056.wav"></audio>
+    <audio data-key="65" src="./sounds/040.wav"></audio>
+    <audio data-key="87" src="./sounds/041.wav"></audio>
+    <audio data-key="83" src="./sounds/042.wav"></audio>
+    <audio data-key="69" src="./sounds/043.wav"></audio>
+    <audio data-key="68" src="./sounds/044.wav"></audio>
+    <audio data-key="70" src="./sounds/045.wav"></audio>
+    <audio data-key="84" src="./sounds/046.wav"></audio>
+    <audio data-key="71" src="./sounds/047.wav"></audio>
+    <audio data-key="89" src="./sounds/048.wav"></audio>
+    <audio data-key="72" src="./sounds/049.wav"></audio>
+    <audio data-key="85" src="./sounds/050.wav"></audio>
+    <audio data-key="74" src="./sounds/051.wav"></audio>
+    <audio data-key="75" src="./sounds/052.wav"></audio>
+    <audio data-key="79" src="./sounds/053.wav"></audio>
+    <audio data-key="76" src="./sounds/054.wav"></audio>
+    <audio data-key="80" src="./sounds/055.wav"></audio>
+    <audio data-key="186" src="./sounds/056.wav"></audio>
   </section>
 
 </body>


### PR DESCRIPTION
Estava assistindo a aula e percebi que as notas musicais não estavam sendo tocadas, ao analisar o problema descobrir que foi causado pela src das tags de audio. Pois nos sistemas operacionais unix uma path que inicia com `/` é um caminho no root do sistema. Ao adicionar um ponto na frente o problema foi resolvido.

Ps: não testei se isso quebra em outros sistemas operacionais.